### PR TITLE
fix: patch url if using git/ssh protocol

### DIFF
--- a/setup/00-intro.sh
+++ b/setup/00-intro.sh
@@ -242,6 +242,8 @@ kubectl create namespace a-team
 ###########
 
 REPO_URL=$(git config --get remote.origin.url)
+# workaround to avoid setting up SSH key in ArgoCD
+REPO_URL=$(echo $REPO_URL | sed 's/git@github.com:/https:\/\/github.com\//') # replace git@github.com: to https://github.com/
 
 yq --inplace ".spec.source.repoURL = \"$REPO_URL\"" argocd/apps.yaml
 


### PR DESCRIPTION
Closes #6 

This line will patch the GitHub repo url if using git/ssh protocol in GH CLI.

A bit of a hack, but will avoid having to setup ssh key in ArgoCD and add to repo.