### PR TITLE
chore: remove duplicate `teller` package

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -12,7 +12,6 @@
     upbound
     teller
     crossplane-cli
-    teller
     kubernetes-helm
   ];
 }


### PR DESCRIPTION
Probably not a huge deal but `teller` shows up twice in the list of packages.