### PR TITLE
Set global.domain in argocd helm values to fix ingress

### DIFF
--- a/argocd/helm-values.yaml
+++ b/argocd/helm-values.yaml
@@ -1,3 +1,5 @@
+global:
+  domain: argocd.127.0.0.1.nip.io
 configs:
   secret:
     argocdServerAdminPassword: "$2a$10$m3eTlEdRen0nS86c5Zph5u/bDFQMcWZYdG3NVdiyaACCqoxLJaz16"
@@ -11,9 +13,5 @@ server:
   ingress:
     enabled: true
     ingressClassName: nginx
-    hosts:
-      - argocd.127.0.0.1.nip.io
   extraArgs:
     - --insecure
-
-


### PR DESCRIPTION
Setting the host name in server.ingress.hosts[0] is apparently not sufficient for the argocd ingress to work. This is fixed by setting global.domain instead. global.domain is used as default value for server.ingress.hosts and several other places as well.

Fixes #15